### PR TITLE
Display stamp image at right side with small device

### DIFF
--- a/views/_form.haml
+++ b/views/_form.haml
@@ -1,5 +1,5 @@
 .row
-  .col-md-6.form-horizontal
+  .col-md-8.col-xs-8.form-horizontal
     .form-group
       %label.col-md-2.control-label{ for: 'textAreaText' } Text
       .col-md-10
@@ -52,5 +52,5 @@
             %button.btn.btn-default.js__clip-button{ data: {'clipboard-target': '#inputMarkdown'} }
               %span.glyphicon.glyphicon-copy
 
-  .col-md-6
+  .col-md-4.col-xs-4
     %img.img-thumbnail.js__stamp-image-url{ src: "/top?text=sample"}


### PR DESCRIPTION
小さいデバイスのときにも、右に小さくスタンプを表示するようにした。