### PR TITLE
Fix text position

### DIFF
--- a/classes/text_image.rb
+++ b/classes/text_image.rb
@@ -37,6 +37,11 @@ class TextImage
     end
     image.trim
     image.resize "#{width}x#{height}"
+    image.combine_options do |c|
+      c.background 'None'
+      c.gravity "center"
+      c.extent "#{width}x#{height}"
+    end
   end
 
   def self.valid_font_name?(font_name)


### PR DESCRIPTION
スタンプに貼り付けるテキストが左上に寄っていたので修正。 