### PR TITLE
Fix text height of thanks a lot

### DIFF
--- a/stamps.yml
+++ b/stamps.yml
@@ -66,7 +66,7 @@
   :textbox_x: 10
   :textbox_y: 10
   :textbox_w: 280
-  :textbox_h: 280
+  :textbox_h: 110
   :textbox_angle: 0
 - :id: thats_great
   :name: thats_great


### PR DESCRIPTION
`thanks a lot`のテキストの高さが直していなかった。